### PR TITLE
Use getattr to check is GuardedModelAdminMixin has the attribute queryse...

### DIFF
--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -66,7 +66,7 @@ class GuardedModelAdminMixin(object):
         # backward compatibility
         method = getattr(
             super(GuardedModelAdminMixin, self), 'get_queryset',
-            super(GuardedModelAdminMixin, self).queryset)
+            getattr(super(GuardedModelAdminMixin, self), 'queryset', None))
         qs = method(request)
 
         if request.user.is_superuser:


### PR DESCRIPTION
...t

We can not check for queryset in Django 1.8 as the attribute is no longer available
The getattr function still checks the default parameter and fails with a AttributeError
as super(GuardedModelAdminMixin, self) has no attribute getquery. We also need to
pass a default parameter (None) to the second getattr call as this will otherwise fail
as well.
